### PR TITLE
don't create new span ctx from headers if already done

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,6 @@ defmodule OpencensusPhoenix.MixProject do
   defp deps do
     [
       {:opencensus, "~> 0.9.0"},
-
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule OpencensusPhoenix.MixProject do
   def project do
     [
       app: :opencensus_phoenix,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/opencensus_phoenix_test.exs
+++ b/test/opencensus_phoenix_test.exs
@@ -2,6 +2,5 @@ defmodule OpencensusPhoenixTest do
   use ExUnit.Case
 
   test "greets the world" do
-
   end
 end


### PR DESCRIPTION
In the event a span was already created based on the headers and placed in the `conn` private field, likely by `opencensus_plug`, create a child span from it instead of based on the propagated context in the headers.