### PR TITLE
feat: Allow configuring span name, and add :route_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ config :my_app, MyAppWeb.Endpoint,
   # ... existing config ...
   instrumenters: [OpencensusPhoenix.Instrumenter]
 ```
+
+# Resource Names
+
+Prior to Phoenix 1.4, the "route info" was not available to plugs. As such instead of using the http route as the resource name, we use the controller + action combination. For example:
+
+* Pre 1.4: `MyApp.Posts.index`
+* Version 1.4 or greater: `/posts`


### PR DESCRIPTION
Chris Mccord messaged me recently to let me know of an awesome new thing in a recent version of phoenix that allows us to finally get the route template :D I'm working on getting things set up to write a spandex to opencensus guide, so I'm contributing this here, instead of on our end. Right now in spandex we get the route in a [very hacky/ugly way](https://github.com/spandex-project/spandex_phoenix/blob/master/lib/spandex_phoenix.ex#L250), so I'm excited to have this.

I made it configurable to retain your current default, and added the ability to configure it as an MFA, but I'm open to any and all feedback here. I just threw this together quick, so we can make any changes necessary. If you like it, I can add documentation/tests to get it up to par.