### PR TITLE
Handle event prefixes correctly & other formats of route_info.action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/opencensus-beam/opencensus_phoenix.svg?style=svg)](https://circleci.com/gh/opencensus-beam/opencensus_phoenix)
 [![Hex version badge](https://img.shields.io/hexpm/v/opencensus_phoenix.svg)](https://hex.pm/packages/opencensus_phoenix)
-## Phoenix 1.5
-Phoenix has abandoned instrumenters in 1.5 in favour of the `:telemetry` library.
+
+Phoenix has abandoned instrumenters in 1.5 in favour of the `:telemetry` library. The following approach should work with all versions of Phoenix.
 
 Simply ensure that the following code runs while your app is starting up (eg, in the `Application.start/2` callback):
 
@@ -23,7 +23,7 @@ def start(_type, _args) do
 end
 ```
 
-## Phoenix 1.4
+## Phoenix <=1.4 only
 [Phoenix instrumenter](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-instrumentation) callback module to automatically create [OpenCensus](http://opencensus.io) spans for Phoenix Controller and View information.
 
 Simply configure your Phoenix `Endpoint` to use this library as one of its `instrumenters`:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 # lib/my_app/application.ex, add this line using event_prefix from above:
 def start(_type, _args) do
   ...
-  OpencensusPhoenix.Telemetry.setup([:my_app, :endpoint])
+  OpencensusPhoenix.Telemetry.setup()
   ...
 end
 ```

--- a/lib/opencensus_phoenix/telemetry.ex
+++ b/lib/opencensus_phoenix/telemetry.ex
@@ -91,7 +91,14 @@ defmodule OpencensusPhoenix.Telemetry do
           %{module: module, action: action}
       end
 
-    :ocp.with_child_span("request.#{route_info.module}.#{route_info.action}")
+    action =
+      case route_info.action do
+        [schema: schema, json_codec: _] -> schema
+        action when is_binary(action) -> action
+        action -> inspect(action)
+      end
+
+    :ocp.with_child_span("request.#{route_info.module}.#{action}")
 
     :ocp.put_attributes(
       Map.merge(route_info, %{


### PR DESCRIPTION
I had hard-coded it with the prefix `[:phoenix, :endpoint]`, but you can of course choose whichever prefix you wish.

I also revised the README to indicate that the telemetry approach works fine for earlier versions of Phoenix (not sure exactly which version of Phoenix integrated `telemetry`, but it works with 1.4 here).